### PR TITLE
Completions | Generalized interface to any Chat Completions API including Anthropic and Mistral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ reqwest = { version = "0.11.11", features = ["json", "multipart", "stream"]}
 lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.19.2", features = ["full"] }
+async-trait = "0.1.66"

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -40,7 +40,7 @@ async fn main() {
     // Get answer using Anthropic
     let anthropic_api_key: String =
         std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
-    let model = AnthropicModels::Claude2; // Choose the model
+    let model = AnthropicModels::ClaudeInstant1_2; // Choose the model
 
     let anthropic_completion = Completions::new(model, &anthropic_api_key, None, None);
 
@@ -60,6 +60,7 @@ async fn main() {
     let mistral_completion = Completions::new(model, &mistral_api_key, None, None);
 
     match mistral_completion
+        .debug()
         .get_answer::<TranslationResponse>(instructions)
         .await
     {

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -1,0 +1,54 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use openai_safe::{
+    llm_models::{AnthropicModels, OpenAIModels},
+    Completions,
+};
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
+struct TranslationResponse {
+    pub spanish: String,
+    pub french: String,
+    pub german: String,
+    pub polish: String,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    // Example context and instructions
+    let instructions =
+        "Translate this exact English sentence to all the languages in the response type";
+
+    // Get answer using OpenAI
+    let openai_api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    let model = OpenAIModels::Gpt4; // Choose the model
+
+    let openai_completion = Completions::new(model, &openai_api_key, None, None);
+
+    match openai_completion
+        .get_answer::<TranslationResponse>(instructions)
+        .await
+    {
+        Ok(response) => println!("OpenAI response: {:?}", response),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+
+    // Get answer using Anthropic
+    let openai_api_key: String =
+        std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
+    let model = AnthropicModels::Claude2; // Choose the model
+
+    let anthropic_completion = Completions::new(model, &openai_api_key, None, None);
+
+    match anthropic_completion
+        .get_answer::<TranslationResponse>(instructions)
+        .await
+    {
+        Ok(response) => println!("Anthropic response: {:?}", response),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+}

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -21,7 +21,7 @@ async fn main() {
 
     // Example context and instructions
     let instructions =
-        "Translate this exact English sentence to all the languages in the response type";
+        "Translate this exact English sentence to all the languages in the response type: \"Hi, how are you?\"";
 
     // Get answer using OpenAI
     let openai_api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
@@ -40,7 +40,7 @@ async fn main() {
     // Get answer using Anthropic
     let anthropic_api_key: String =
         std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
-    let model = AnthropicModels::ClaudeInstant1_2; // Choose the model
+    let model = AnthropicModels::Claude2; // Choose the model
 
     let anthropic_completion = Completions::new(model, &anthropic_api_key, None, None);
 
@@ -55,7 +55,7 @@ async fn main() {
     // Get answer using Mistral
     let mistral_api_key: String =
         std::env::var("MISTRAL_API_KEY").expect("MISTRAL_API_KEY not set");
-    let model = MistralModels::MistralMedium; // Choose the model
+    let model = MistralModels::MistralTiny; // Choose the model
 
     let mistral_completion = Completions::new(model, &mistral_api_key, None, None);
 

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use openai_safe::{
-    llm_models::{AnthropicModels, OpenAIModels},
+    llm_models::{AnthropicModels, MistralModels, OpenAIModels},
     Completions,
 };
 
@@ -38,17 +38,32 @@ async fn main() {
     }
 
     // Get answer using Anthropic
-    let openai_api_key: String =
+    let anthropic_api_key: String =
         std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
     let model = AnthropicModels::Claude2; // Choose the model
 
-    let anthropic_completion = Completions::new(model, &openai_api_key, None, None);
+    let anthropic_completion = Completions::new(model, &anthropic_api_key, None, None);
 
     match anthropic_completion
         .get_answer::<TranslationResponse>(instructions)
         .await
     {
         Ok(response) => println!("Anthropic response: {:?}", response),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+
+    // Get answer using Mistral
+    let mistral_api_key: String =
+        std::env::var("MISTRAL_API_KEY").expect("MISTRAL_API_KEY not set");
+    let model = MistralModels::MistralMedium; // Choose the model
+
+    let mistral_completion = Completions::new(model, &mistral_api_key, None, None);
+
+    match mistral_completion
+        .get_answer::<TranslationResponse>(instructions)
+        .await
+    {
+        Ok(response) => println!("Mistral response: {:?}", response),
         Err(e) => eprintln!("Error: {:?}", e),
     }
 }

--- a/examples/use_openai.rs
+++ b/examples/use_openai.rs
@@ -21,7 +21,8 @@ async fn main() {
     let open_ai = OpenAI::new(&api_key, model, None, None);
 
     // Example context and instructions
-    let instructions = "Translate this English text to all the languages in the response type";
+    let instructions =
+        "Translate this exact English sentence to all the languages in the response type";
 
     match open_ai
         .get_answer::<TranslationResponse>(instructions)

--- a/examples/use_openai.rs
+++ b/examples/use_openai.rs
@@ -16,16 +16,14 @@ struct TranslationResponse {
 async fn main() {
     env_logger::init();
     let api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let model = OpenAIModels::AnthropicClaude2; // Choose the model
+    let model = OpenAIModels::Gpt4; // Choose the model
 
     let open_ai = OpenAI::new(&api_key, model, None, None);
 
     // Example context and instructions
-    let instructions =
-        "Translate the following English text to all the languages in the response type";
+    let instructions = "Translate this English text to all the languages in the response type";
 
     match open_ai
-        .debug()
         .get_answer::<TranslationResponse>(instructions)
         .await
     {

--- a/examples/use_openai.rs
+++ b/examples/use_openai.rs
@@ -16,7 +16,7 @@ struct TranslationResponse {
 async fn main() {
     env_logger::init();
     let api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let model = OpenAIModels::Gpt3_5Turbo; // Choose the model
+    let model = OpenAIModels::AnthropicClaude2; // Choose the model
 
     let open_ai = OpenAI::new(&api_key, model, None, None);
 
@@ -25,6 +25,7 @@ async fn main() {
         "Translate the following English text to all the languages in the response type";
 
     match open_ai
+        .debug()
         .get_answer::<TranslationResponse>(instructions)
         .await
     {

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -201,19 +201,19 @@ impl<T: LLMModel> Completions<T> {
         let response_string = self.model.get_data(&response_text, self.function_call)?;
 
         if self.debug {
-            info!("[debug] OpenAI response data: {}", response_string);
+            info!("[debug] Completions response data: {}", response_string);
         }
         //Deserialize the string response into the expected output type
         let response_deser: anyhow::Result<U, anyhow::Error> =
             serde_json::from_str(&response_string).map_err(|error| {
-                error!("[OpenAI] Response serialization error: {}", &error);
+                error!("[Completions] Response serialization error: {}", &error);
                 anyhow!("Error: {}", error)
             });
         // Sometimes openai responds with a json object that has a data property. If that's the case, we need to extract the data property and deserialize that.
         if let Err(_e) = response_deser {
             let response_deser: OpenAIDataResponse<U> = serde_json::from_str(&response_text)
                 .map_err(|error| {
-                    error!("[OpenAI] Response serialization error: {}", &error);
+                    error!("[Completions] Response serialization error: {}", &error);
                     anyhow!("Error: {}", error)
                 })?;
             Ok(response_deser.data)

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -210,6 +210,7 @@ impl<T: LLMModel> Completions<T> {
                 anyhow!("Error: {}", error)
             });
         // Sometimes openai responds with a json object that has a data property. If that's the case, we need to extract the data property and deserialize that.
+        // TODO: This is OpenAI specific and should be implemented within the model.
         if let Err(_e) = response_deser {
             let response_deser: OpenAIDataResponse<U> = serde_json::from_str(&response_text)
                 .map_err(|error| {

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -4,15 +4,14 @@ use schemars::{schema_for, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 
-use crate::{domain::OpenAIDataResponse, models::OpenAIModels, utils::get_tokenizer_old};
+use crate::llm_models::LLMModel;
+use crate::{domain::OpenAIDataResponse, utils::get_tokenizer};
 
-/// [Chat Completions API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api)
-///
-/// Chat models take a list of messages as input and return a model-generated message as output.
-/// Although the chat format is designed to make multi-turn conversations easy,
+/// Completions APIs take a list of messages as input and return a model-generated message as output.
+/// Although the Completions format is designed to make multi-turn conversations easy,
 /// it’s just as useful for single-turn tasks without any conversation.
-pub struct OpenAI {
-    model: OpenAIModels,
+pub struct Completions<T: LLMModel> {
+    model: T,
     //For prompt & response
     max_tokens: usize,
     temperature: u32,
@@ -22,15 +21,15 @@ pub struct OpenAI {
     api_key: String,
 }
 
-impl OpenAI {
+impl<T: LLMModel> Completions<T> {
     ///
     pub fn new(
-        open_ai_key: &str,
-        model: OpenAIModels,
+        model: T,
+        api_key: &str,
         max_tokens: Option<usize>,
         temperature: Option<u32>,
     ) -> Self {
-        OpenAI {
+        Completions {
             //If no max tokens limit is provided we default to max allowed for the model
             max_tokens: max_tokens.unwrap_or_else(|| model.default_max_tokens()),
             function_call: model.function_call_default(),
@@ -38,7 +37,7 @@ impl OpenAI {
             temperature: temperature.unwrap_or(0u32), //Low number makes the output less random and more deterministic
             input_json: None,
             debug: false,
-            api_key: open_ai_key.to_string(),
+            api_key: api_key.to_string(),
         }
     }
 
@@ -63,7 +62,7 @@ impl OpenAI {
      * Using this function you can provide multiple input values by calling it multiple times. New values will be appended with the category name
      * It accepts any instance that implements the Serialize trait.
      */
-    pub fn set_context<T: Serialize>(mut self, input_name: &str, input_data: &T) -> Result<Self> {
+    pub fn set_context<U: Serialize>(mut self, input_name: &str, input_data: &U) -> Result<Self> {
         let input_json = if let Ok(json) = serde_json::to_string(&input_data) {
             json
         } else {
@@ -88,12 +87,12 @@ impl OpenAI {
      * This method is used to check how many tokens would most likely remain for the response
      * This is accomplished by estimating number of tokens needed for system/base instructions, user prompt, and function components including schema definition.
      */
-    pub fn check_prompt_tokens<T: JsonSchema + DeserializeOwned>(
+    pub fn check_prompt_tokens<U: JsonSchema + DeserializeOwned>(
         &self,
         instructions: &str,
     ) -> Result<usize> {
         //Output schema is extracted from the type parameter
-        let schema = schema_for!(T);
+        let schema = schema_for!(U);
         let json_value: Value = serde_json::to_value(&schema)?;
 
         let prompt = format!(
@@ -119,7 +118,7 @@ impl OpenAI {
         );
 
         //Check how many tokens are required for prompt
-        let bpe = get_tokenizer_old(&self.model)?;
+        let bpe = get_tokenizer(&self.model)?;
         let prompt_tokens = bpe.encode_with_special_tokens(&full_prompt).len();
 
         //Assuming another 5% overhead for json formatting
@@ -131,12 +130,12 @@ impl OpenAI {
      * When calling the function you need to specify the type parameter as the response will match the schema of that type.
      * The prompt in this function is written in a way to instruct OpenAI to behave like a computer function that calculates an output based on provided input and its language model.
      */
-    pub async fn get_answer<T: JsonSchema + DeserializeOwned>(
+    pub async fn get_answer<U: JsonSchema + DeserializeOwned>(
         self,
         instructions: &str,
-    ) -> Result<T> {
+    ) -> Result<U> {
         //Output schema is extracted from the type parameter
-        let schema = schema_for!(T);
+        let schema = schema_for!(U);
         let json_value: Value = serde_json::to_value(&schema)?;
 
         let prompt = format!(
@@ -153,7 +152,7 @@ impl OpenAI {
 
         //Validate how many tokens remain for the response (and how many are used for prompt)
         let prompt_tokens = self
-            .check_prompt_tokens::<T>(instructions)
+            .check_prompt_tokens::<U>(instructions)
             .unwrap_or_default();
 
         if prompt_tokens >= self.max_tokens {
@@ -205,14 +204,14 @@ impl OpenAI {
             info!("[debug] OpenAI response data: {}", response_string);
         }
         //Deserialize the string response into the expected output type
-        let response_deser: anyhow::Result<T, anyhow::Error> =
+        let response_deser: anyhow::Result<U, anyhow::Error> =
             serde_json::from_str(&response_string).map_err(|error| {
                 error!("[OpenAI] Response serialization error: {}", &error);
                 anyhow!("Error: {}", error)
             });
         // Sometimes openai responds with a json object that has a data property. If that's the case, we need to extract the data property and deserialize that.
         if let Err(_e) = response_deser {
-            let response_deser: OpenAIDataResponse<T> = serde_json::from_str(&response_text)
+            let response_deser: OpenAIDataResponse<U> = serde_json::from_str(&response_text)
                 .map_err(|error| {
                     error!("[OpenAI] Response serialization error: {}", &error);
                     anyhow!("Error: {}", error)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,16 @@ lazy_static! {
         std::env::var("OPENAI_API_URL").unwrap_or("https://api.openai.com".to_string());
 }
 
+lazy_static! {
+    pub(crate) static ref ANTHROPIC_API_URL: String = std::env::var("ANTHROPIC_API_URL")
+        .unwrap_or("https://api.anthropic.com/v1/complete".to_string());
+}
+
+lazy_static! {
+    pub(crate) static ref MISTRAL_API_URL: String = std::env::var("MISTRAL_API_URL")
+        .unwrap_or("https://api.mistral.ai/v1/chat/completions".to_string());
+}
+
 //Generic OpenAI instructions
 pub(crate) const OPENAI_BASE_INSTRUCTIONS: &str = r#"You are a computer function. You are expected to perform the following tasks:
 Step 1: Review and understand the 'instructions' from the *Instructions* section.

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -212,3 +212,14 @@ impl OpenAIFile {
         Ok(())
     }
 }
+
+//Anthropic API response type format for Text Completions API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AnthropicAPICompletionsResponse {
+    pub id: String,
+    #[serde(rename(deserialize = "type", serialize = "type"))]
+    pub request_type: String,
+    pub completion: String,
+    pub stop_reason: String,
+    pub model: String,
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -223,3 +223,37 @@ pub struct AnthropicAPICompletionsResponse {
     pub stop_reason: String,
     pub model: String,
 }
+
+//Mistral API response type format for Chat Completions API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct MistralAPICompletionsResponse {
+    pub id: Option<String>,
+    pub object: Option<String>,
+    pub created: Option<usize>,
+    pub model: Option<String>,
+    pub choices: Vec<MistralAPICompletionsChoices>,
+    pub usage: Option<MistralAPICompletionsUsage>,
+}
+
+//Mistral API response type format for Chat Completions API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct MistralAPICompletionsChoices {
+    pub index: usize,
+    pub message: Option<MistralAPICompletionsMessage>,
+    pub finish_reason: String,
+}
+
+//Mistral API response type format for Chat Completions API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct MistralAPICompletionsMessage {
+    pub role: Option<String>,
+    pub content: Option<String>,
+}
+
+//Mistral API response type format for Chat Completions API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct MistralAPICompletionsUsage {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -64,7 +64,7 @@ pub struct OpenAPIUsage {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct OpenAIRateLimit {
+pub struct RateLimit {
     pub tpm: usize, // tokens-per-minute
     pub rpm: usize, // requests-per-minute
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,15 @@
 mod assistant;
+mod completions;
 mod constants;
 mod domain;
 mod enums;
+pub mod llm_models;
 mod models;
 mod openai;
 mod utils;
 
 pub use crate::assistant::OpenAIAssistant;
+pub use crate::completions::Completions;
 pub use crate::domain::OpenAIFile;
 pub use crate::models::OpenAIModels;
 pub use crate::openai::OpenAI;

--- a/src/llm_models/anthropic.rs
+++ b/src/llm_models/anthropic.rs
@@ -64,7 +64,7 @@ impl LLMModel for AnthropicModels {
         }
     }
     /*
-     * This function leverages OpenAI API to perform any query as per the provided body.
+     * This function leverages Anthropic API to perform any query as per the provided body.
      *
      * It returns a String the Response object that needs to be parsed based on the self.model.
      */
@@ -97,7 +97,7 @@ impl LLMModel for AnthropicModels {
 
         if debug {
             info!(
-                "[debug] OpenAI API response: [{}] {:#?}",
+                "[debug] Anthropic API response: [{}] {:#?}",
                 &response_status, &response_text
             );
         }

--- a/src/llm_models/anthropic.rs
+++ b/src/llm_models/anthropic.rs
@@ -5,11 +5,13 @@ use reqwest::{header, Client};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::constants::ANTHROPIC_API_URL;
 use crate::{domain::AnthropicAPICompletionsResponse, llm_models::LLMModel};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum AnthropicModels {
     Claude2,
+    ClaudeInstant1_2,
 }
 
 #[async_trait(?Send)]
@@ -17,21 +19,20 @@ impl LLMModel for AnthropicModels {
     fn as_str(&self) -> &'static str {
         match self {
             AnthropicModels::Claude2 => "claude-2.1",
+            AnthropicModels::ClaudeInstant1_2 => "claude-instant-1.2",
         }
     }
 
     fn default_max_tokens(&self) -> usize {
-        //This is the max tokens allowed for response
+        //This is the max tokens allowed for response and not context as per documentation: https://docs.anthropic.com/claude/reference/input-and-output-sizes
         match self {
             AnthropicModels::Claude2 => 4_096,
+            AnthropicModels::ClaudeInstant1_2 => 4_096,
         }
     }
 
     fn get_endpoint(&self) -> String {
-        match self {
-            //TODO: Move to env var
-            AnthropicModels::Claude2 => "https://api.anthropic.com/v1/complete".to_string(),
-        }
+        ANTHROPIC_API_URL.to_string()
     }
 
     //This method prepares the body of the API call for different models
@@ -43,25 +44,21 @@ impl LLMModel for AnthropicModels {
         max_tokens: &usize,
         temperature: &u32,
     ) -> serde_json::Value {
-        match self {
-            AnthropicModels::Claude2 => {
-                let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
-                let base_instructions = self.get_base_instructions(Some(function_call));
-                json!({
-                    "model": self.as_str(),
-                    "max_tokens_to_sample": max_tokens,
-                    "temperature": temperature,
-                    "prompt": format!(
-                        "\n\nHuman:
-                        {base_instructions}\n\n
-                        Output Json schema:\n
-                        {schema_string}\n\n
-                        {instructions}
-                        \n\nAssistant:",
-                    ),
-                })
-            }
-        }
+        let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
+        let base_instructions = self.get_base_instructions(Some(function_call));
+        json!({
+            "model": self.as_str(),
+            "max_tokens_to_sample": max_tokens,
+            "temperature": temperature,
+            "prompt": format!(
+                "\n\nHuman:
+                {base_instructions}\n\n
+                Output Json schema:\n
+                {schema_string}\n\n
+                {instructions}
+                \n\nAssistant:",
+            ),
+        })
     }
     /*
      * This function leverages Anthropic API to perform any query as per the provided body.
@@ -107,15 +104,11 @@ impl LLMModel for AnthropicModels {
 
     //This method attempts to convert the provided API response text into the expected struct and extracts the data from the response
     fn get_data(&self, response_text: &str, _function_call: bool) -> Result<String> {
-        match self {
-            AnthropicModels::Claude2 => {
-                //Convert API response to struct representing expected response format
-                let completions_response: AnthropicAPICompletionsResponse =
-                    serde_json::from_str(response_text)?;
+        //Convert API response to struct representing expected response format
+        let completions_response: AnthropicAPICompletionsResponse =
+            serde_json::from_str(response_text)?;
 
-                //Return completions text
-                Ok(completions_response.completion)
-            }
-        }
+        //Return completions text
+        Ok(completions_response.completion)
     }
 }

--- a/src/llm_models/anthropic.rs
+++ b/src/llm_models/anthropic.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use log::info;
+use reqwest::{header, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::{domain::AnthropicAPICompletionsResponse, llm_models::LLMModel};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum AnthropicModels {
+    Claude2,
+}
+
+#[async_trait(?Send)]
+impl LLMModel for AnthropicModels {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AnthropicModels::Claude2 => "claude-2.1",
+        }
+    }
+
+    fn default_max_tokens(&self) -> usize {
+        //This is the max tokens allowed for response
+        match self {
+            AnthropicModels::Claude2 => 4_096,
+        }
+    }
+
+    fn get_endpoint(&self) -> String {
+        match self {
+            //TODO: Move to env var
+            AnthropicModels::Claude2 => "https://api.anthropic.com/v1/complete".to_string(),
+        }
+    }
+
+    //This method prepares the body of the API call for different models
+    fn get_body(
+        &self,
+        instructions: &str,
+        json_schema: &Value,
+        function_call: bool,
+        max_tokens: &usize,
+        temperature: &u32,
+    ) -> serde_json::Value {
+        match self {
+            AnthropicModels::Claude2 => {
+                let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
+                let base_instructions = self.get_base_instructions(Some(function_call));
+                json!({
+                    "model": self.as_str(),
+                    "max_tokens_to_sample": max_tokens,
+                    "temperature": temperature,
+                    "prompt": format!(
+                        "\n\nHuman:
+                        {base_instructions}\n\n
+                        Output Json schema:\n
+                        {schema_string}\n\n
+                        {instructions}
+                        \n\nAssistant:",
+                    ),
+                })
+            }
+        }
+    }
+    /*
+     * This function leverages OpenAI API to perform any query as per the provided body.
+     *
+     * It returns a String the Response object that needs to be parsed based on the self.model.
+     */
+    async fn call_api(
+        &self,
+        api_key: &str,
+        body: &serde_json::Value,
+        debug: bool,
+    ) -> Result<String> {
+        //Get the API url
+        let model_url = self.get_endpoint();
+
+        //Make the API call
+        let client = Client::new();
+
+        //Send request
+        let response = client
+            .post(model_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            //Anthropic-specific way of passing API key
+            .header("x-api-key", api_key)
+            //Required as per documentation
+            .header("anthropic-version", "2023-06-01")
+            .json(&body)
+            .send()
+            .await?;
+
+        let response_status = response.status();
+        let response_text = response.text().await?;
+
+        if debug {
+            info!(
+                "[debug] OpenAI API response: [{}] {:#?}",
+                &response_status, &response_text
+            );
+        }
+
+        Ok(response_text)
+    }
+
+    //This method attempts to convert the provided API response text into the expected struct and extracts the data from the response
+    fn get_data(&self, response_text: &str, _function_call: bool) -> Result<String> {
+        match self {
+            AnthropicModels::Claude2 => {
+                //Convert API response to struct representing expected response format
+                let completions_response: AnthropicAPICompletionsResponse =
+                    serde_json::from_str(response_text)?;
+
+                //Return completions text
+                Ok(completions_response.completion)
+            }
+        }
+    }
+}

--- a/src/llm_models/llm_model.rs
+++ b/src/llm_models/llm_model.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::constants::OPENAI_BASE_INSTRUCTIONS;
+use crate::domain::RateLimit;
+
+///This trait defines functions that need to be implemented for an enum that represents an LLM Model from any of the API providers
+#[async_trait(?Send)]
+pub trait LLMModel {
+    ///Converts each item in the model enum into its string representation
+    fn as_str(&self) -> &'static str;
+    ///Returns max supported number of tokens for each of the variants of the enum
+    fn default_max_tokens(&self) -> usize;
+    ///Returns the url of the endpoint that should be called for each variant of the LLM Model enum
+    fn get_endpoint(&self) -> String;
+    ///Provides a list of base instructions that should be added to each prompt when using each of the models
+    fn get_base_instructions(&self, _function_call: Option<bool>) -> String {
+        OPENAI_BASE_INSTRUCTIONS.to_string()
+    }
+    ///Returns recommendation if function calling should be used for the specified model
+    fn function_call_default(&self) -> bool {
+        false
+    }
+    ///Constructs the body that should be attached to the API call for each of the LLM Models
+    fn get_body(
+        &self,
+        instructions: &str,
+        json_schema: &Value,
+        function_call: bool,
+        max_tokens: &usize,
+        temperature: &u32,
+    ) -> serde_json::Value;
+    ///Makes the call to the correct API for the selected model
+    async fn call_api(
+        &self,
+        api_key: &str,
+        body: &serde_json::Value,
+        debug: bool,
+    ) -> Result<String>;
+    ///Based on the model type extracts the data portion of the API response
+    fn get_data(&self, response_text: &str, function_call: bool) -> Result<String>;
+    ///Returns the rate limit accepted by the API depending on the used model
+    ///If not explicitly defined it will assume 1B tokens or 100k transactions a minute
+    fn get_rate_limit(&self) -> RateLimit {
+        RateLimit {
+            tpm: 100_000_000,
+            rpm: 100_000,
+        }
+    }
+    ///Based on the RateLimit for the model calculates how many requests can be send to the API
+    fn get_max_requests(&self) -> usize {
+        let rate_limit = self.get_rate_limit();
+
+        //Check max requests based on rpm
+        let max_requests_from_rpm = rate_limit.rpm;
+
+        //Double check max number of requests based on tpm
+        //Assume we will use ~50% of allowed tokens per request (for prompt + response)
+        let max_tokens_per_minute = rate_limit.tpm;
+        let tpm_per_request = (self.default_max_tokens() as f64 * 0.5).ceil() as usize;
+        //Then check how many requests we can process
+        let max_requests_from_tpm = max_tokens_per_minute / tpm_per_request;
+
+        //To be safe we go with smaller of the numbers
+        std::cmp::min(max_requests_from_rpm, max_requests_from_tpm)
+    }
+}

--- a/src/llm_models/mistral.rs
+++ b/src/llm_models/mistral.rs
@@ -5,6 +5,7 @@ use reqwest::{header, Client};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::constants::MISTRAL_API_URL;
 use crate::{
     domain::{MistralAPICompletionsResponse, RateLimit},
     llm_models::LLMModel,
@@ -34,8 +35,7 @@ impl LLMModel for MistralModels {
     }
 
     fn get_endpoint(&self) -> String {
-        //TODO: Move to env var
-        "https://api.mistral.ai/v1/chat/completions".to_string()
+        MISTRAL_API_URL.to_string()
     }
 
     //This method prepares the body of the API call for different models

--- a/src/llm_models/mistral.rs
+++ b/src/llm_models/mistral.rs
@@ -1,0 +1,138 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use log::info;
+use reqwest::{header, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::{
+    domain::{MistralAPICompletionsResponse, RateLimit},
+    llm_models::LLMModel,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+//Mistral docs: https://docs.mistral.ai/platform/endpoints
+pub enum MistralModels {
+    MistralTiny,
+    MistralSmall,
+    MistralMedium,
+}
+
+#[async_trait(?Send)]
+impl LLMModel for MistralModels {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MistralModels::MistralTiny => "mistral-tiny",
+            MistralModels::MistralSmall => "mistral-small",
+            MistralModels::MistralMedium => "mistral-medium",
+        }
+    }
+
+    fn default_max_tokens(&self) -> usize {
+        //"All our generative endpoints can reason on contexts up to 32k tokens and follow fine-grained instructions. "
+        32_000
+    }
+
+    fn get_endpoint(&self) -> String {
+        //TODO: Move to env var
+        "https://api.mistral.ai/v1/chat/completions".to_string()
+    }
+
+    //This method prepares the body of the API call for different models
+    fn get_body(
+        &self,
+        instructions: &str,
+        json_schema: &Value,
+        function_call: bool,
+        max_tokens: &usize,
+        temperature: &u32,
+    ) -> serde_json::Value {
+        //Prepare the 'messages' part of the body
+        let base_instructions = self.get_base_instructions(Some(function_call));
+        let system_message = json!({
+            "role": "system",
+            "content": base_instructions,
+        });
+        let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
+        let user_message = json!({
+            "role": "user",
+            "content": format!(
+                "Output Json schema:\n
+                {schema_string}\n\n
+                {instructions}"
+            ),
+        });
+        json!({
+            "model": self.as_str(),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": vec![
+                system_message,
+                user_message,
+            ],
+        })
+    }
+    /*
+     * This function leverages Mistral API to perform any query as per the provided body.
+     *
+     * It returns a String the Response object that needs to be parsed based on the self.model.
+     */
+    async fn call_api(
+        &self,
+        api_key: &str,
+        body: &serde_json::Value,
+        debug: bool,
+    ) -> Result<String> {
+        //Get the API url
+        let model_url = self.get_endpoint();
+
+        //Make the API call
+        let client = Client::new();
+
+        //Send request
+        let response = client
+            .post(model_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await?;
+
+        let response_status = response.status();
+        let response_text = response.text().await?;
+
+        if debug {
+            info!(
+                "[debug] Mistral API response: [{}] {:#?}",
+                &response_status, &response_text
+            );
+        }
+
+        Ok(response_text)
+    }
+
+    //This method attempts to convert the provided API response text into the expected struct and extracts the data from the response
+    fn get_data(&self, response_text: &str, _function_call: bool) -> Result<String> {
+        //Convert API response to struct representing expected response format
+        let completions_response: MistralAPICompletionsResponse =
+            serde_json::from_str(response_text)?;
+
+        //Parse the response and return the assistant content
+        completions_response
+            .choices
+            .iter()
+            .filter_map(|choice| choice.message.as_ref())
+            .find(|&message| message.role.as_ref() == Some(&"assistant".to_string()))
+            .and_then(|message| message.content.clone())
+            .ok_or_else(|| anyhow!("Assistant role content not found"))
+    }
+
+    //This function allows to check the rate limits for different models
+    fn get_rate_limit(&self) -> RateLimit {
+        //Mistral documentation: https://docs.mistral.ai/platform/pricing#rate-limits
+        RateLimit {
+            tpm: 2_000_000,
+            rpm: 120, // 2 request per second
+        }
+    }
+}

--- a/src/llm_models/mod.rs
+++ b/src/llm_models/mod.rs
@@ -1,7 +1,9 @@
 pub mod anthropic;
 pub mod llm_model;
+pub mod mistral;
 pub mod open_ai;
 
 pub use anthropic::AnthropicModels;
 pub use llm_model::LLMModel;
+pub use mistral::MistralModels;
 pub use open_ai::OpenAIModels;

--- a/src/llm_models/mod.rs
+++ b/src/llm_models/mod.rs
@@ -1,0 +1,7 @@
+pub mod anthropic;
+pub mod llm_model;
+pub mod open_ai;
+
+pub use anthropic::AnthropicModels;
+pub use llm_model::LLMModel;
+pub use open_ai::OpenAIModels;

--- a/src/llm_models/open_ai.rs
+++ b/src/llm_models/open_ai.rs
@@ -319,7 +319,8 @@ impl LLMModel for OpenAIModels {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::OpenAIModels;
+    use crate::llm_models::llm_model::LLMModel;
+    use crate::llm_models::OpenAIModels;
     use crate::utils::get_tokenizer;
 
     #[test]

--- a/src/llm_models/open_ai.rs
+++ b/src/llm_models/open_ai.rs
@@ -321,20 +321,6 @@ impl LLMModel for OpenAIModels {
 mod tests {
     use crate::llm_models::llm_model::LLMModel;
     use crate::llm_models::OpenAIModels;
-    use crate::utils::get_tokenizer;
-
-    #[test]
-    fn it_computes_gpt3_5_tokenization() {
-        let bpe = get_tokenizer(&OpenAIModels::Gpt4_32k).unwrap();
-        let tokenized: Result<Vec<_>, _> = bpe
-            .split_by_token_iter("This is a test         with a lot of spaces", true)
-            .collect();
-        let tokenized = tokenized.unwrap();
-        assert_eq!(
-            tokenized,
-            vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]
-        );
-    }
 
     // Tests for calculating max requests per model
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -382,11 +382,11 @@ impl OpenAIModels {
 #[cfg(test)]
 mod tests {
     use crate::models::OpenAIModels;
-    use crate::utils::get_tokenizer;
+    use crate::utils::get_tokenizer_old;
 
     #[test]
     fn it_computes_gpt3_5_tokenization() {
-        let bpe = get_tokenizer(&OpenAIModels::Gpt4_32k).unwrap();
+        let bpe = get_tokenizer_old(&OpenAIModels::Gpt4_32k).unwrap();
         let tokenized: Result<Vec<_>, _> = bpe
             .split_by_token_iter("This is a test         with a lot of spaces", true)
             .collect();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,21 @@
 use tiktoken_rs::{cl100k_base, get_bpe_from_model, CoreBPE};
 
+use crate::llm_models::LLMModel;
 use crate::models::OpenAIModels;
 
 // Get the tokenizer given a model
-pub(crate) fn get_tokenizer(model: &OpenAIModels) -> anyhow::Result<CoreBPE> {
+pub(crate) fn get_tokenizer_old(model: &OpenAIModels) -> anyhow::Result<CoreBPE> {
+    let tokenizer = get_bpe_from_model(model.as_str());
+    if let Err(_error) = tokenizer {
+        // Fallback to the default chat model
+        cl100k_base()
+    } else {
+        tokenizer
+    }
+}
+
+// Get the tokenizer given a model
+pub(crate) fn get_tokenizer<T: LLMModel>(model: &T) -> anyhow::Result<CoreBPE> {
     let tokenizer = get_bpe_from_model(model.as_str());
     if let Err(_error) = tokenizer {
         // Fallback to the default chat model

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,3 +31,22 @@ pub(crate) fn sanitize_json_response(json_response: &str) -> String {
     let text_no_json = json_response.replace("json\n", "");
     text_no_json.replace("```", "")
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::llm_models::OpenAIModels;
+    use crate::utils::get_tokenizer;
+
+    #[test]
+    fn it_computes_gpt3_5_tokenization() {
+        let bpe = get_tokenizer(&OpenAIModels::Gpt4_32k).unwrap();
+        let tokenized: Result<Vec<_>, _> = bpe
+            .split_by_token_iter("This is a test         with a lot of spaces", true)
+            .collect();
+        let tokenized = tokenized.unwrap();
+        assert_eq!(
+            tokenized,
+            vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]
+        );
+    }
+}


### PR DESCRIPTION
This PR changes the nature of the crate to not only support OpenAI APIs but also models exposed by other LLM providers. It introduces a standard way of adding new models and a new abstraction called Completions that can be used with any model from any provider.

Key highlights:
- [ ] `llm_models::LLMModel` trait is the centerpiece of changes. It specifies what functions need to be implemented for an enum containing LLM Models from a provider for that enum to work with the `Completions` struct.
- [ ] `llm_models::OpenAIModels` is a re-implementation of the previously existing `models::OpenAIModels` but through implementation of the new trait.
- [ ] `llm_models::AnthropicModels` and `llm_models::MistralModels` are new model enums for Anthropic and Mistral respectively.
- [ ] `Completions` is a new module that is mostly a direct copy of the previously existing `openai` module, just modified to accept any enum that implements the new trait as model attribute.
- [ ] `use_completions` is a new file to test how different models work.
- [ ] `openai` module and `models::OpenAIModels` were purposefully unchanged to ensure backwards compatibility. We should probably add some depreciation warnings and remove them over time.